### PR TITLE
Update Readme with the latest infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ In fact, if any of this information is out of date or incomplete, please update 
 </thead>
 <tbody>
 
-<tr><td rowspan="2"><a href="http://docs.webplatform.org/wiki/css/properties/clip-path">clip-path</a> with basic shapes</td><td>HTML</td><td>No</td><td>-webkit-clip-path</td><td>No</td><td>No</td><td></td></tr>
+<tr><td rowspan="2"><a href="http://docs.webplatform.org/wiki/css/properties/clip-path">clip-path</a> with basic shapes</td><td>HTML</td><td>-webkit-clip-path</td><td>-webkit-clip-path</td><td>No</td><td>No</td><td></td></tr>
 <tr><td>SVG</td><td>No</td><td>-webkit-clip-path</td><td>No</td><td>No</td><td></td></tr>
 
-<tr><td rowspan="2"><a href="http://docs.webplatform.org/wiki/css/properties/clip-path">clip-path</a> with SVG path</td><td>HTML</td><td>No</td><td>-webkit-clip-path</td><td>No</td><td>No</td><td></td></tr>
+<tr><td rowspan="2"><a href="http://docs.webplatform.org/wiki/css/properties/clip-path">clip-path</a> with SVG path</td><td>HTML</td><td>-webkit-clip-path (buggy)</td><td>-webkit-clip-path (buggy)</td><td>clip-path</td><td>No</td><td></td></tr>
 <tr><td>SVG</td><td>clip-path</td><td>clip-path</td><td>clip-path</td><td>clip-path</td><td></td></tr>
 
 <tr><td rowspan="2"><a href="http://docs.webplatform.org/wiki/css/properties/mask-image">mask-image</a></td><td>HTML</td><td>-webkit-mask-image</td><td>-webkit-mask-image</td><td>No</td><td>No</td><td>Uses alpha masking</td></tr>
@@ -32,7 +32,7 @@ In fact, if any of this information is out of date or incomplete, please update 
 <tr><td rowspan="2"><a href="http://docs.webplatform.org/wiki/css/properties/mask">mask</a></td><td>HTML</td><td>No</td><td>No</td><td>mask</td><td>No</td><td></td></tr>
 <tr><td>SVG</td><td>mask</td><td>mask</td><td>mask</td><td>mask</td><td>Uses luminance masking</td></tr>
 
-<tr><td rowspan="2"><a href="http://docs.webplatform.org/wiki/css/properties/filter">SVG Filter</a></td><td>HTML</td><td>No</td><td>-webkit-filter</td><td>filter</td><td>No</td><td></td></tr>
+<tr><td rowspan="2"><a href="http://docs.webplatform.org/wiki/css/properties/filter">SVG Filter</a></td><td>HTML</td><td>-webkit-filter</td><td>-webkit-filter</td><td>filter</td><td>No</td><td></td></tr>
 <tr><td>SVG</td><td>filter</td><td>filter</td><td>filter</td><td>filter</td><td></td></tr>
 </tbody>
 </table>


### PR DESCRIPTION
This chart is very useful so i updated it. Safari 6.1 now supports -webkit-clip-path with basic shapes on HTML content and -webkit-filter. But i haven't test if clip-path is supported on SVG content. Firefox supports clip-path with SVG on HTML content.

Let me know if you find something wrong.

Vincent
